### PR TITLE
Automatic NuGet packaging & publishing

### DIFF
--- a/HiP-WebserviceLib.csproj
+++ b/HiP-WebserviceLib.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Version>2.1.0</Version>
+	<Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/HiP-WebserviceLib.sln
+++ b/HiP-WebserviceLib.sln
@@ -1,5 +1,5 @@
 
-Microsoft Visual Studio Solution File, Format Version 15.00
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2017
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HiP-WebserviceLib", "HiP-WebserviceLib.csproj", "{EE159CF5-B9BE-4389-AE0C-677FB2399BF8}"
 EndProject

--- a/NuGetPack.ps1
+++ b/NuGetPack.ps1
@@ -1,0 +1,9 @@
+Switch ("$env:Build_SourceBranchName")
+{
+	"master" { dotnet pack "HiP-WebserviceLib.csproj" -o . }
+	"develop" { dotnet pack "HiP-WebserviceLib.csproj" -o . --version-suffix "develop" }
+	default { exit }
+}
+
+$nupkg = (ls *.nupkg).FullName
+dotnet nuget push "$nupkg" -k "$env:MyGetKey" -s "$env:MyGetFeed"


### PR DESCRIPTION
This PR adds a new script that is used during TFS builds to automatically create and publish a NuGet package of HiP-WebserviceLib to our MyGet feed.

`MyGetKey` and `MyGetFeed` are defined as variables in the TFS build definition.
