### PR TITLE
Refactored NuGet packaging

### DIFF
--- a/HiP-WebserviceLib.csproj
+++ b/HiP-WebserviceLib.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.1.0</Version>
-	<Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <RootNamespace>PaderbornUniversity.SILab.Hip.Webservice</RootNamespace>
+    <Version>2.1.1</Version>
+	<Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NuGetPack.ps1
+++ b/NuGetPack.ps1
@@ -6,4 +6,4 @@ Switch ("$env:Build_SourceBranchName")
 }
 
 $nupkg = (ls *.nupkg).FullName
-dotnet nuget push "$nupkg" -k "$env:MyGetKey" -s "$env:MyGetFeed"
+dotnet nuget push "$nupkg" -k "$env:MyGetKey" -s "$env:NuGetFeed"


### PR DESCRIPTION
According to the guidelines on Confluence, the packaging script should use the "NuGetFeed"-variable instead of "MyGetFeed"