### PR TITLE
HIPCMS-906: Added FakeAuthentication for testing scenarios (v3.2.0)

### DIFF
--- a/FakeAuthentication.cs
+++ b/FakeAuthentication.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+
+namespace PaderbornUniversity.SILab.Hip.Webservice
+{
+    /// <summary>
+    /// Provides an extension method to register fake authentication (in an ASP.NET Core Startup class).
+    /// </summary>
+    public static class FakeAuthentication
+    {
+        public const string AuthenticationScheme = "FakeScheme";
+
+        public static AuthenticationBuilder AddFakeAuthenticationScheme(this AuthenticationBuilder authenticationBuilder) =>
+            authenticationBuilder.AddScheme<FakeAuthenticationOptions, FakeAuthenticationHandler>(
+                AuthenticationScheme, options => { });
+    }
+
+    /// <summary>
+    /// Fakes authentication/authorization by pretending there's an authenticated user.
+    /// 
+    /// The ID and the role of the fake user are taken from the HTTP header "Authorization",
+    /// so this header should not (as usual) contain an auth token, but rather the user ID and
+    /// role separated by a dash, e.g. "SampleAdmin-Administrator".
+    /// 
+    /// Requirements (e.g. "read:datastore") are not checked, we just pretend that they are fulfilled.
+    /// 
+    /// Written with guidance from https://github.com/aspnet/Security/issues/1360.
+    /// </summary>
+    public class FakeAuthenticationHandler : AuthenticationHandler<FakeAuthenticationOptions>
+    {
+        public FakeAuthenticationHandler(
+            IOptionsMonitor<FakeAuthenticationOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder,
+            ISystemClock clock)
+            : base(options, logger, encoder, clock)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var userAndRole = ((string)Context.Request.Headers["Authorization"])?.Split('-');
+
+            if (userAndRole == null)
+                return Task.FromResult(AuthenticateResult.NoResult());
+
+            var userId = userAndRole[0];
+            var role = userAndRole.Length > 1 ? userAndRole[1] : "";
+
+            var identity = new ClaimsIdentity(
+                new[]
+                {
+                    new Claim("https://hip.cs.upb.de/sub", userId),
+                    new Claim("https://hip.cs.upb.de/roles", role)
+                },
+                FakeAuthentication.AuthenticationScheme);
+
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, identity.AuthenticationType);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+
+    public class FakeAuthenticationOptions : AuthenticationSchemeOptions
+    {
+    }
+}

--- a/HiP-WebserviceLib.csproj
+++ b/HiP-WebserviceLib.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>PaderbornUniversity.SILab.Hip.Webservice</RootNamespace>
     <NoWarn>1701;1702;1705;1591</NoWarn>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
`FakeAuthentication` and its related types provide an alternative authentication scheme that is useful in test projects: During tests we do not want to work with JWT tokens, we just want to simulate different users with different roles. `FakeAuthentication` makes this easy. Instead of...
```CSharp
services
    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
    .AddJwtBearer(options =>
    {
        options.Audience = authConfig.Value.Audience;
        options.Authority = authConfig.Value.Authority;
    });
```

...we can just write...

```CSharp
services
    .AddAuthentication(FakeAuthentication.AuthenticationScheme)
    .AddFakeAuthenticationScheme();
```

...and instead of a real JWT token like "Bearer eyJ0eXAiO..." we can include something like "SampleAdmin-Administrator" (user ID and role separated by a dash) in the HTTP Authorization header to authorize against the microservice running in test mode.

The new library version is v3.2.0.
See also the [related PR in HiP-EventStoreLib](https://github.com/HiP-App/HiP-EventStoreLib/pull/14).
See also the [related PR in HiP-DataStore](https://github.com/HiP-App/HiP-DataStore/pull/109).