### PR TITLE
HIPCMS-1033 Additions

### DIFF
--- a/HiP-WebserviceLib.csproj
+++ b/HiP-WebserviceLib.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>PaderbornUniversity.SILab.Hip.Webservice</RootNamespace>
     <NoWarn>1701;1702;1705;1591</NoWarn>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/RequestSchemeFixerExtensions.cs
+++ b/RequestSchemeFixerExtensions.cs
@@ -23,6 +23,8 @@ namespace PaderbornUniversity.SILab.Hip.Webservice
             {
                 if (context.Request.Headers.TryGetValue("X-Forwarded-Proto", out var xproto))
                     context.Request.Scheme = xproto;
+                if (context.Request.Headers.TryGetValue("X-Forwarded-Path", out var xpath))
+                    context.Request.PathBase = new PathString(xpath);
                 await next();
             });
         }


### PR DESCRIPTION
'X-Forwarded-Path', which will be set by nginx, has to be added to the request. This was necessary, because after the upgrade to .net core 2.1, the host of the request is not accepted if it contains the host and the path. Therefore the host and the path have to be seperated by nginx.